### PR TITLE
fix SELinux xattr

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -75,7 +75,8 @@ OBJECTS += \
 	extension/hidden_files/hidden_files.o \
 	extension/port_switch/port_switch.o \
 	extension/link2symlink/link2symlink.o \
-	extension/fix_symlink_size/fix_symlink_size.o
+	extension/fix_symlink_size/fix_symlink_size.o \
+	extension/fix_selinux_xattr/fix_selinux_xattr.o
 
 define define_from_arch.h
 $2$1 := $(shell $(CC) $1 -E -dM -DNO_LIBC_HEADER $(SRC)/arch.h | grep -w $2 | cut -f 3 -d ' ')

--- a/src/cli/proot.c
+++ b/src/cli/proot.c
@@ -298,6 +298,12 @@ static int handle_option_L(Tracee *tracee, const Cli *cli UNUSED, const char *va
         return 0;
 }
 
+static int handle_option_fix_selinux_xattr(Tracee *tracee, const Cli *cli UNUSED, const char *value UNUSED)
+{
+        (void) initialize_extension(tracee, fix_selinux_xattr_callback, NULL);
+        return 0;
+}
+
 static int handle_option_H(Tracee *tracee, const Cli *cli UNUSED, const char *value UNUSED)
 {
         (void) initialize_extension(tracee, hidden_files_callback, NULL);

--- a/src/cli/proot.h
+++ b/src/cli/proot.h
@@ -63,6 +63,7 @@ static int handle_option_S(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_link2symlink(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_kill_on_exit(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_L(Tracee *tracee, const Cli *cli, const char *value);
+static int handle_option_fix_selinux_xattr(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_H(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_p(Tracee *tracee, const Cli *cli, const char *value);
 
@@ -263,6 +264,15 @@ Copyright (C) 2015 STMicroelectronics, licensed under GPL v2 or later.",
           .handler = handle_option_L,
           .description = "Correct the size returned from lstat for symbolic links.",
           .detail = "",
+        },
+        { .class = "Extension options",
+          .arguments = {
+                { .name = "--fix-selinux-xattr", .separator = '\0', .value = NULL },
+                { .name = NULL, .separator = '\0', .value = NULL } },
+          .handler = handle_option_fix_selinux_xattr,
+          .description = "Fix the status returned from setxattr for the SELinux attribute.",
+          .detail = "\tChanges the value of setxattr from EACCES to zero when trying to \
+overwrite security.selinux with an identical value.",
         },
 	{ .class = "Alias options",
 	  .arguments = {

--- a/src/cli/proot.h
+++ b/src/cli/proot.h
@@ -271,8 +271,8 @@ Copyright (C) 2015 STMicroelectronics, licensed under GPL v2 or later.",
                 { .name = NULL, .separator = '\0', .value = NULL } },
           .handler = handle_option_fix_selinux_xattr,
           .description = "Fix the status returned from setxattr for the SELinux attribute.",
-          .detail = "\tChanges the value of setxattr from EACCES to zero when trying to \
-overwrite security.selinux with an identical value.",
+          .detail = "\tChanges the value of setxattr from EACCES or EPERM to ENOTSUP \
+ when trying to write security.selinux.",
         },
 	{ .class = "Alias options",
 	  .arguments = {

--- a/src/extension/extension.h
+++ b/src/extension/extension.h
@@ -199,5 +199,6 @@ extern int hidden_files_callback(Extension *extension, ExtensionEvent event, int
 extern int port_switch_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
 extern int link2symlink_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
 extern int fix_symlink_size_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
+extern int fix_selinux_xattr_callback(Extension *extension, ExtensionEvent event, intptr_t d1, intptr_t d2);
 
 #endif /* EXTENSION_H */

--- a/src/extension/fix_selinux_xattr/fix_selinux_xattr.c
+++ b/src/extension/fix_selinux_xattr/fix_selinux_xattr.c
@@ -3,8 +3,8 @@
  * Date:   18/12/2018
  *
  * Description: An extension that changes the return
- * value of setxattr from EACCES to zero when trying
- * to overwrite security.selinux with an identical value.
+ * value of setxattr from EACCES or EPERM to ENOTSUP
+ * when trying to write security.selinux.
  */
 
 #include <sys/xattr.h>
@@ -14,8 +14,8 @@
 const unsigned int MAX_NAME_LENGTH = 17;
 
 /**
- * Return zero instead of EACCES when trying
- * to overwrite security.selinux with an identical value.
+ * Return ENOTSUP instead of EACCES or EPERM
+ * when trying to write security.selinux.
  */
 static int handle_setxattr(Tracee *tracee)
 {
@@ -26,16 +26,14 @@ static int handle_setxattr(Tracee *tracee)
     case PR_fsetxattr: {
         /* get the result of the syscall */
         word_t res = peek_reg(tracee, CURRENT, SYSARG_RESULT);
-        if (res != -EACCES) {
+        /* EACCESS is also returned, when access to the file is denied */
+        if (res != -EACCES && res != -EPERM) {
             return 0;
         }
 
         /* get the system call arguments */
         word_t fd_or_path_start = peek_reg(tracee, MODIFIED, SYSARG_1);
         word_t name_start = peek_reg(tracee, CURRENT, SYSARG_2);
-        word_t value_start = peek_reg(tracee, CURRENT, SYSARG_3);
-        word_t value_size = peek_reg(tracee, CURRENT, SYSARG_4);
-        word_t flags = peek_reg(tracee, CURRENT, SYSARG_5);
 
         /* check if the attribute name is security.selinux */
         char name[MAX_NAME_LENGTH];
@@ -47,55 +45,7 @@ static int handle_setxattr(Tracee *tracee)
             return 0;
         }
 
-        /* check if the current value and the new value are the same */
-        /* retrieve the new value */
-        char value[value_size];
-        status = read_data(tracee, value, value_start, value_size);
-        if (status < 0) {
-            return status;
-        }
-        /* retrieve the current value from the file system */
-        char current_value[value_size];
-        char path[PATH_MAX];
-        if (sysnum == PR_fsetxattr) {
-            status = snprintf(path, PATH_MAX, "/proc/%d/fd/%d", tracee->pid, fd_or_path_start);
-            if (status < 0 || status >= PATH_MAX) {
-                return -EBADF;
-            }
-        } else {
-            status = read_string(tracee, path, fd_or_path_start, PATH_MAX);
-            if (status < 0) {
-                return status;
-            }
-        }
-        if (sysnum == PR_lsetxattr) {
-            status = lgetxattr(path, name, current_value, value_size);
-        } else {
-            status = getxattr(path, name, current_value, value_size);
-        }
-        /* the values can't be equal in this cases */
-        if (status == -E2BIG || status == -ERANGE || status == -ENODATA) {
-            return 0;
-        }
-        /* either the original EACCES error was caused by file permissions or
-         * a new error happened (e.g. the file was deleted in the meantime) */
-        if (status < 0) {
-            poke_reg(tracee, SYSARG_RESULT, status);
-            return 0;
-        }
-        /* compare the current and the new value */
-        if (status != value_size || memcmp(value, current_value, value_size) != 0) {
-            return 0;
-        }
-
-        /* check flags */
-        if (flags&XATTR_CREATE) {
-            poke_reg(tracee, SYSARG_RESULT, -EEXIST);
-            return 0;
-        }
-
-        /* return zero */
-        poke_reg(tracee, SYSARG_RESULT, 0);
+        poke_reg(tracee, SYSARG_RESULT, -ENOTSUP);
         return 0;
     }
 

--- a/src/extension/fix_selinux_xattr/fix_selinux_xattr.c
+++ b/src/extension/fix_selinux_xattr/fix_selinux_xattr.c
@@ -1,0 +1,135 @@
+/*
+ * Author: Unrud
+ * Date:   18/12/2018
+ *
+ * Description: An extension that changes the return
+ * value of setxattr from EACCES to zero when trying
+ * to overwrite security.selinux with an identical value.
+ */
+
+#include <sys/xattr.h>
+#include "extension/extension.h"
+#include "tracee/mem.h"
+
+const unsigned int MAX_NAME_LENGTH = 17;
+
+/**
+ * Return zero instead of EACCES when trying
+ * to overwrite security.selinux with an identical value.
+ */
+static int handle_setxattr(Tracee *tracee)
+{
+    Sysnum sysnum = get_sysnum(tracee, ORIGINAL);
+    switch (sysnum) {
+    case PR_setxattr: 
+    case PR_lsetxattr:
+    case PR_fsetxattr: {
+        /* get the result of the syscall */
+        word_t res = peek_reg(tracee, CURRENT, SYSARG_RESULT);
+        if (res != -EACCES) {
+            return 0;
+        }
+
+        /* get the system call arguments */
+        word_t fd_or_path_start = peek_reg(tracee, MODIFIED, SYSARG_1);
+        word_t name_start = peek_reg(tracee, CURRENT, SYSARG_2);
+        word_t value_start = peek_reg(tracee, CURRENT, SYSARG_3);
+        word_t value_size = peek_reg(tracee, CURRENT, SYSARG_4);
+        word_t flags = peek_reg(tracee, CURRENT, SYSARG_5);
+
+        /* check if the attribute name is security.selinux */
+        char name[MAX_NAME_LENGTH];
+        int status = read_string(tracee, name, name_start, MAX_NAME_LENGTH);
+        if (status < 0) {
+            return status;
+        }
+        if (strncmp("security.selinux", name, MAX_NAME_LENGTH) != 0) {
+            return 0;
+        }
+
+        /* check if the current value and the new value are the same */
+        /* retrieve the new value */
+        char value[value_size];
+        status = read_data(tracee, value, value_start, value_size);
+        if (status < 0) {
+            return status;
+        }
+        /* retrieve the current value from the file system */
+        char current_value[value_size];
+        char path[PATH_MAX];
+        if (sysnum == PR_fsetxattr) {
+            status = snprintf(path, PATH_MAX, "/proc/%d/fd/%d", tracee->pid, fd_or_path_start);
+            if (status < 0 || status >= PATH_MAX) {
+                return -EBADF;
+            }
+        } else {
+            status = read_string(tracee, path, fd_or_path_start, PATH_MAX);
+            if (status < 0) {
+                return status;
+            }
+        }
+        if (sysnum == PR_lsetxattr) {
+            status = lgetxattr(path, name, current_value, value_size);
+        } else {
+            status = getxattr(path, name, current_value, value_size);
+        }
+        /* the values can't be equal in this cases */
+        if (status == -E2BIG || status == -ERANGE || status == -ENODATA) {
+            return 0;
+        }
+        /* either the original EACCES error was caused by file permissions or
+         * a new error happened (e.g. the file was deleted in the meantime) */
+        if (status < 0) {
+            poke_reg(tracee, SYSARG_RESULT, status);
+            return 0;
+        }
+        /* compare the current and the new value */
+        if (status != value_size || memcmp(value, current_value, value_size) != 0) {
+            return 0;
+        }
+
+        /* check flags */
+        if (flags&XATTR_CREATE) {
+            poke_reg(tracee, SYSARG_RESULT, -EEXIST);
+            return 0;
+        }
+
+        /* return zero */
+        poke_reg(tracee, SYSARG_RESULT, 0);
+        return 0;
+    }
+
+    default:
+        return 0;
+    }
+}
+
+/**
+ * Handler for this @extension.  It is triggered each time an @event
+ * occured.  See ExtensionEvent for the meaning of @data1 and @data2.
+ */
+int fix_selinux_xattr_callback(Extension *extension, ExtensionEvent event,
+        intptr_t data1 UNUSED, intptr_t data2 UNUSED)
+{
+    switch (event) {
+    case INITIALIZATION: {
+        /* List of syscalls handled by this extension */
+        static FilteredSysnum filtered_sysnums[] = {
+            { PR_setxattr,   FILTER_SYSEXIT },
+            { PR_lsetxattr,  FILTER_SYSEXIT },
+            { PR_fsetxattr,  FILTER_SYSEXIT },
+            FILTERED_SYSNUM_END,
+        };
+        extension->filtered_sysnums = filtered_sysnums;
+        return 0;
+    }
+
+    case SYSCALL_CHAINED_EXIT:
+    case SYSCALL_EXIT_END: {
+        return handle_setxattr(TRACEE(extension));
+    }
+
+    default:
+        return 0;
+    }
+}


### PR DESCRIPTION
Android returns **EACCES** when trying to overwrite the extended attribute ``security.selinux`` with an identical value. This breaks many programs that try to copy extended attributes. (e.g. [shutil.copy2](https://docs.python.org/3.7/library/shutil.html#shutil.copy2) from the Python standard library doesn't work.)

On my desktop computer this problem doesn't occur, because the kernel only returns **EACCES** when I try to overwrite ``security.selinux`` with a different value.

This PR adds an extension that changes the return value of **setxattr** from **EACCES** to zero when trying to overwrite ``security.selinux`` with an identical value.