### PR TITLE
Add extra checks for SiGSEV on PR_void system calls

### DIFF
--- a/src/tracee/seccomp.c
+++ b/src/tracee/seccomp.c
@@ -389,12 +389,19 @@ static int handle_seccomp_event_common(Tracee *tracee)
 
 	//required for when an extention changes the sysnum to PR_void and that gets picked up by the filtering
 	case PR_void:
-		set_result_after_seccomp(tracee, 0);
-		break;
+		if (peek_reg(tracee, CURRENT, SYSARG_NUM) == SYSCALL_AVOIDER) {
+			VERBOSE(tracee, 9, "SIGSYS PR_void handled, and 0 returned");
+			set_result_after_seccomp(tracee, 0);
+			break;
+		}
+
+		VERBOSE(tracee, 9, "SIGSYS PR_void handled, but not for SYSCALL_AVOIDER. Falling through to default handling");
+		/* fall-through */
 
 	case PR_set_robust_list:
 	default:
 		/* Set errno to -ENOSYS */
+		VERBOSE(tracee, 9, "SIGSYS. Return set to -ENOSYS");
 		set_result_after_seccomp(tracee, -ENOSYS);
 	}
 


### PR DESCRIPTION
When extensions handle system calls they set the system call ID to 0
(PR_void). This is the same as what happens if a system call isn't
understood by proot. On Android unknown system calls result in a SECCOMP
failure (sending SIGSYS), rather than returning ENOSYS.

This changes the behavour of SIGSYS handing to check if the call was
handled by an extension. If the call was handled by an extention the
call should return 0, since it has been handled outside that context. If
it wasn't handled then we should return ENOSYS. This is because either
that system call doesn't exist, or we aren't allowed to call it. Either
way, since the point of proot is to adapt seccomp to other applications,
we should return ENOSYS because as far as the system is concerned that
system call doesn't exist.

Major props to nhinds for writing a bunch of go programs to help narrow
this down to the the SECCOMP filter and the handing of the SISSYS
signal.

This fixes headmelted/codebuilds#97 and CypherpunkArmory/UserLAnd#938